### PR TITLE
Fix: Test endpoint now returns hardcoded html page.

### DIFF
--- a/src/main/java/ru/tubryansk/tdms/controller/TestController.java
+++ b/src/main/java/ru/tubryansk/tdms/controller/TestController.java
@@ -4,12 +4,14 @@ package ru.tubryansk.tdms.controller;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
 
 
 @Controller
 @RequestMapping("/")
 public class TestController {
     @GetMapping
+    @ResponseBody
     public String root() {
         return """
                 <!DOCTYPE html>


### PR DESCRIPTION
add ResponseBody annotation to TestController root method to successfully returns hard-coded html page.